### PR TITLE
Trim down installer pathway

### DIFF
--- a/cell-forms/readme.md
+++ b/cell-forms/readme.md
@@ -11,12 +11,6 @@
 <!---- Insert UI example image here -->
 
 ```
-pip install jupyter-cell-form-dbconn
-```
-
-vs.
-
-```
 jupyter template install http://example.com/cell-forms/dbconn.json
 ```
 


### PR DESCRIPTION
As suggested in #12, let's only show the example with a jupyter app for installing rather than including a `pip` way to install templates.